### PR TITLE
Add Python 2.6 for CentOS/RHEL 6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"


### PR DESCRIPTION
Compatibility for CentOS/RHEL 6
